### PR TITLE
Add sudo to make install step of integrated plugin with Wireshark build

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The following steps are required to build and install the plugin as part of Wire
     cd build
     cmake ..
     make
-    make install
+    sudo make install
     ```
 
 


### PR DESCRIPTION
As we discussed in issue 24 ( https://github.com/SecureAuthCorp/SAP-Dissection-plug-in-for-Wireshark/issues/24 ) it makes sense to run the eponymous step using sudo. 